### PR TITLE
Bluetooth: Allow tx_pwr to be read when not BT_CONN

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -11506,8 +11506,10 @@ u8_t ll_tx_pwr_lvl_get(u16_t handle, u8_t type, s8_t *tx_pwr_lvl)
 
 	/*TODO: check type here for current or maximum */
 
-	/* TODO: Support TX Power Level other than 0dBm */
-	*tx_pwr_lvl = 0;
+	/* TODO: Support TX Power Level other than default when dynamic
+	 *       updates is implemented.
+	 */
+	*tx_pwr_lvl = RADIO_TXP_DEFAULT;
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ctrl.c
+++ b/subsys/bluetooth/controller/ll_sw/ctrl.c
@@ -11495,25 +11495,6 @@ u8_t ll_terminate_ind_send(u16_t handle, u8_t reason)
 	return 0;
 }
 
-u8_t ll_tx_pwr_lvl_get(u16_t handle, u8_t type, s8_t *tx_pwr_lvl)
-{
-	struct connection *conn;
-
-	conn = connection_get(handle);
-	if (!conn) {
-		return BT_HCI_ERR_UNKNOWN_CONN_ID;
-	}
-
-	/*TODO: check type here for current or maximum */
-
-	/* TODO: Support TX Power Level other than default when dynamic
-	 *       updates is implemented.
-	 */
-	*tx_pwr_lvl = RADIO_TXP_DEFAULT;
-
-	return 0;
-}
-
 #if defined(CONFIG_BT_CTLR_CONN_RSSI)
 u8_t ll_rssi_get(u16_t handle, u8_t *rssi)
 {
@@ -11668,6 +11649,18 @@ u8_t ll_phy_req_send(u16_t handle, u8_t tx, u8_t flags, u8_t rx)
 }
 #endif /* CONFIG_BT_CTLR_PHY */
 #endif /* CONFIG_BT_CONN */
+
+u8_t ll_tx_pwr_lvl_get(u16_t handle, u8_t type, s8_t *tx_pwr_lvl)
+{
+	/*TODO: check type here for current or maximum */
+
+	/* TODO: Support TX Power Level other than default when dynamic
+	 *       updates is implemented.
+	 */
+	*tx_pwr_lvl = RADIO_TXP_DEFAULT;
+
+	return 0;
+}
 
 static u8_t tx_cmplt_get(u16_t *handle, u8_t *first, u8_t last)
 {

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -1,32 +1,52 @@
 /*
- * Copyright (c) 2016-2017 Nordic Semiconductor ASA
+ * Copyright (c) 2016-2019 Nordic Semiconductor ASA
  * Copyright (c) 2016 Vinayak Kariappa Chettimada
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/types.h>
-
-/* TODO: Remove weak attribute when refactored architecture replaces the old
- *       controller implementation. */
 #include <toolchain.h>
+#include <soc.h>
+#include <bluetooth/hci.h>
 
-u8_t __weak ll_tx_pwr_lvl_get(u16_t handle, u8_t type, s8_t *tx_pwr_lvl)
+#include "hal/ccm.h"
+#include "hal/radio.h"
+
+#include "util/memq.h"
+
+#include "pdu.h"
+
+#include "lll.h"
+#include "lll_conn.h"
+#include "ull_conn_internal.h"
+
+#if defined(CONFIG_BT_LL_SW_SPLIT)
+u8_t ll_tx_pwr_lvl_get(u16_t handle, u8_t type, s8_t *tx_pwr_lvl)
 {
-	/* TODO: check for active connection */
+	struct ll_conn *conn;
+
+	conn = ll_connected_get(handle);
+	if (!conn) {
+		return BT_HCI_ERR_UNKNOWN_CONN_ID;
+	}
 
 	/* TODO: check type here for current or maximum */
 
-	/* TODO: Support TX Power Level other than 0dBm */
-	*tx_pwr_lvl = 0;
+	/* TODO: Support TX Power Level other than default when dynamic
+	 *       updates is implemented.
+	 */
+	*tx_pwr_lvl = RADIO_TXP_DEFAULT;
 
 	return 0;
 }
+#endif
 
 void ll_tx_pwr_get(s8_t *min, s8_t *max)
 {
-	/* TODO: Support TX Power Level other than 0dBm */
-	*min = 0;
-	*max = 0;
+	/* TODO: Support TX Power Level other than default when dynamic
+	 *       updates is implemented.
+	 */
+	*min = RADIO_TXP_DEFAULT;
+	*max = RADIO_TXP_DEFAULT;
 }
-

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -141,7 +141,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	radio_reset();
 	/* TODO: other Tx Power settings */
-	radio_tx_power_set(0);
+	radio_tx_power_set(RADIO_TXP_DEFAULT);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* TODO: if coded we use S8? */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -145,7 +145,7 @@ static int prepare_cb(struct lll_prepare_param *prepare_param)
 
 	radio_reset();
 	/* TODO: other Tx Power settings */
-	radio_tx_power_set(0);
+	radio_tx_power_set(RADIO_TXP_DEFAULT);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* TODO: if coded we use S8? */


### PR DESCRIPTION
The beacon sample, a connection-less BT sample, is failing. It fails
because hci.c assumes there exists a function for reading out the TX
power, but ll_sw/ctrl.c does not define one when not BT_CONN.

We fix this by moving ll_tx_pwr_lvl_get such that it is defined when
not BT_CONN. This is safe because all ll_tx_pwr_lvl_get does is write
a static value to an output variable. It was also checking for a valid
connection, but this is not necessary, so this has been dropped.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>